### PR TITLE
Fix loing setup for new version of polygon cli

### DIFF
--- a/polygon_to_ejudge/import_problem.py
+++ b/polygon_to_ejudge/import_problem.py
@@ -62,6 +62,7 @@ def import_problem(
         ejudge_problem_id=None,
         no_offline=False
 ) -> None:
+    cli_config.setup_login_by_url('')
     session = problem.ProblemSession(cli_config.polygon_url, polygon_id, None)
     contest_dir = get_ejudge_contest_dir(ejudge_contest_id)
     download_dir = os.path.join(contest_dir, 'download')
@@ -335,6 +336,7 @@ def import_contest(
         polygon_id: int,
         no_offline=False
 ) -> None:
+    cli_config.setup_login_by_url('')
     session = problem.ProblemSession(cli_config.polygon_url, None, None)
     problems = session.send_api_request('contest.problems', {'contestId': polygon_id}, problem_data=False)
     problem_keys = list(problems.keys())


### PR DESCRIPTION
Без этого фикса падает вот так:
```
Traceback (most recent call last):
  File "/home/chegor/.local/bin/polygon-to-ejudge", line 33, in <module>
    sys.exit(load_entry_point('polygon-to-ejudge==1.0', 'console_scripts', 'polygon-to-ejudge')())
  File "/home/chegor/.local/lib/python3.9/site-packages/polygon_to_ejudge-1.0-py3.9.egg/polygon_to_ejudge/polygon_to_ejudge.py", line 31, in main
  File "/home/chegor/.local/lib/python3.9/site-packages/polygon_to_ejudge-1.0-py3.9.egg/polygon_to_ejudge/import_problem.py", line 368, in <lambda>
  File "/home/chegor/.local/lib/python3.9/site-packages/polygon_to_ejudge-1.0-py3.9.egg/polygon_to_ejudge/import_problem.py", line 339, in import_contest
  File "/home/chegor/.local/lib/python3.9/site-packages/polygon_cli-1.1.10-py3.9.egg/polygon_cli/problem.py", line 190, in send_api_request
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

Разломал совместимость вот этот коммит: https://github.com/kunyavskiy/polygon-cli/commit/41ad6f2baf959e3f95ca2bea1ebb3f1d1ed31606
Теперь без setup'а там None'ы